### PR TITLE
feat: Rebrand site to Resistoma and update social media links

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <!-- Configuración básica del documento -->
     <meta charset="UTF-8"> <!-- Define la codificación de caracteres como UTF-8, esencial para la correcta visualización de acentos y caracteres especiales -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0"> <!-- Configura la vista para dispositivos móviles, asegurando que la página sea responsive (se adapte al ancho del dispositivo) y la escala inicial sea 1 -->
-    <title>Tienda Estilo Samsung</title> <!-- Título que aparecerá en la pestaña del navegador y es importante para SEO -->
+    <title>App Resistoma</title> <!-- Título que aparecerá en la pestaña del navegador y es importante para SEO -->
 
     <!-- Enlace a la hoja de estilos CSS externa -->
     <link rel="stylesheet" href="style.css"> <!-- Conecta este HTML con el archivo style.css que contendrá todos los estilos visuales -->
@@ -25,7 +25,7 @@
         <nav class="navbar">
             <div class="container"> <!-- Contenedor para centrar y limitar el ancho del contenido de la barra de navegación, mejorando la legibilidad en pantallas anchas -->
                 <!-- Marca o Logo del Sitio -->
-                <a href="index.html" class="navbar-brand">SamsungStyle</a> <!-- Enlace al inicio (index.html) con el nombre de la marca. Es importante que el logo siempre lleve a la página principal -->
+                <a href="index.html" class="navbar-brand">Resistoma</a> <!-- Enlace al inicio (index.html) con el nombre de la marca. Es importante que el logo siempre lleve a la página principal -->
 
                 <!-- Lista de Enlaces de Navegación Principal -->
                 <ul class="navbar-nav">
@@ -184,13 +184,11 @@
             </div>
             <!-- Sección Inferior del Pie de Página -->
             <div class="footer-bottom">
-                <p>&copy; 2024 SamsungStyle. Todos los derechos reservados.</p> <!-- Información de Copyright -->
+                <p>&copy; 2024 Resistoma. Todos los derechos reservados.</p> <!-- Información de Copyright -->
                 <!-- Iconos de Redes Sociales -->
                 <div class="social-icons">
-                    <a href="#" aria-label="Visita nuestra página de Facebook"><i class="bi bi-facebook"></i></a> <!-- Icono Bootstrap: Facebook -->
-                    <a href="#" aria-label="Síguenos en Twitter"><i class="bi bi-twitter-x"></i></a> <!-- Icono Bootstrap: Twitter X -->
-                    <a href="#" aria-label="Descubre nuestro Instagram"><i class="bi bi-instagram"></i></a> <!-- Icono Bootstrap: Instagram -->
-                    <a href="#" aria-label="Mira nuestros videos en YouTube"><i class="bi bi-youtube"></i></a> <!-- Icono Bootstrap: YouTube -->
+                    <a href="https://www.facebook.com/profile.php?id=61577841425989" target="_blank" rel="noopener noreferrer" aria-label="Visita nuestra página de Facebook"><i class="bi bi-facebook"></i></a> <!-- Icono Bootstrap: Facebook -->
+                    <a href="https://www.youtube.com/@i_lars" target="_blank" rel="noopener noreferrer" aria-label="Mira nuestros videos en YouTube"><i class="bi bi-youtube"></i></a> <!-- Icono Bootstrap: YouTube -->
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Updated social media links in the footer:
    - Facebook link now points to the provided profile.
    - YouTube link now points to the provided channel.
- Removed Instagram and Twitter (X) icons and links from the footer.
- Replaced all instances of the placeholder brand name 'SamsungStyle' with 'Resistoma' in:
    - Navbar brand text.
    - Footer copyright notice.
- Changed the website's HTML title (browser tab title) from 'Tienda Estilo Samsung' to 'App Resistoma'.
- Verified aria-labels for remaining social media icons and ensured layout consistency after icon removal.