### PR TITLE
feat: Replace email checkout with Wompi link and add order ID generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,11 +250,15 @@
             </div>
             <div class="cart-summary">
                 <p>Total: <span id="cart-total-price">$0.00</span></p>
+                <div id="order-id-display" class="order-id-display" style="display: none;">
+                    <p>ID de tu Pedido: <strong id="current-order-id"></strong><br><small>(Guarda este ID para referencia)</small></p>
+                </div>
             </div>
             <div class="cart-actions">
-                <button id="whatsapp-checkout-btn" class="btn btn-success btn-checkout"><i class="bi bi-whatsapp"></i> Enviar por WhatsApp</button>
-                <button id="email-checkout-btn" class="btn btn-secondary btn-checkout"><i class="bi bi-envelope-fill"></i> Enviar por Email</button>
-                <!-- <button id="wompi-checkout-btn" class="btn btn-info btn-checkout">Pagar con Wompi (Simulado)</button> -->
+                <button id="whatsapp-checkout-btn" class="btn btn-success btn-checkout"><i class="bi bi-whatsapp"></i> Enviar Pedido por WhatsApp</button>
+                <a href="https://checkout.wompi.co/l/VPOS_20Q1Zc" id="wompi-checkout-btn" class="btn btn-primary btn-checkout" target="_blank" rel="noopener noreferrer">
+                    <i class="bi bi-credit-card-fill"></i> Pagar con Wompi
+                </a>
             </div>
         </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -646,6 +646,32 @@ body.dark-mode .cart-item-quantity input {
     font-style: italic;
 }
 
+.order-id-display {
+    margin-top: 1rem;
+    padding: 0.8rem;
+    background-color: var(--background-color); /* Un fondo sutil */
+    border: 1px dashed var(--border-color); /* Borde discontinuo para destacar */
+    border-radius: 6px;
+    text-align: center;
+    font-size: 0.9rem;
+}
+body.dark-mode .order-id-display {
+    background-color: var(--surface-color); /* Fondo de superficie en modo oscuro */
+    border-color: var(--border-color-darker);
+}
+.order-id-display p {
+    margin: 0;
+    line-height: 1.4;
+}
+.order-id-display strong {
+    font-family: 'Courier New', Courier, monospace; /* Fuente monoespaciada para el ID */
+    word-break: break-all; /* Para que IDs largos no rompan el layout */
+}
+.order-id-display small {
+    font-size: 0.8em;
+    color: var(--text-color-secondary);
+}
+
 
 :root {
     /* Tema Claro (por defecto) */


### PR DESCRIPTION
- Updated cart actions in `index.html`:
    - Removed 'Send via Email' button.
    - Added 'Pay with Wompi' button linking to the specified Wompi payment URL (https://checkout.wompi.co/l/VPOS_20Q1Zc), opening in a new tab.
    - Added a display area (`#order-id-display`) in the cart modal to show a generated order ID.
- Implemented order ID generation in `script.js`:
    - Created `generateOrderId()` function using `crypto.randomUUID()` with a fallback.
    - Order ID is now generated when initiating WhatsApp or Wompi checkout.
    - The generated order ID is displayed to the user in the cart modal and via an alert.
    - The order ID is included in the pre-filled WhatsApp message.
- Implemented cart clearing functionality (`clearCart()` function) which is called after initiating a WhatsApp or Wompi checkout (with a short delay to allow redirection/tab opening).
- Updated relevant Spanish comments in HTML and JavaScript.